### PR TITLE
Remove dependency on noflet

### DIFF
--- a/ansi.el
+++ b/ansi.el
@@ -33,6 +33,8 @@
 (require 'dash)
 (require 's)
 
+(require 'cl-lib)
+
 
 
 (defconst ansi-colors

--- a/ansi.el
+++ b/ansi.el
@@ -33,7 +33,13 @@
 (require 'dash)
 (require 's)
 
-(require 'cl-lib)
+(when (version<= "24.3" emacs-version)
+  (require 'cl-lib))
+
+;; Compatability alias for versions before cl-flet was introduced.
+(defalias 'ansi--cl-flet (if (version<= "24.3" emacs-version)
+                             'cl-flet
+                           'flet))
 
 
 
@@ -105,7 +111,7 @@
 
 (defmacro with-ansi (&rest body)
   "In this block shortcut names (without ansi- prefix) can be used."
-  `(cl-flet
+  `(ansi--cl-flet
        ,(-map
          (lambda (alias)
            (let ((fn (intern (format "ansi-%s" (symbol-name alias)))))

--- a/ansi.el
+++ b/ansi.el
@@ -7,7 +7,7 @@
 ;; Version: 0.4.0
 ;; Keywords: color, ansi
 ;; URL: http://github.com/rejeep/ansi
-;; Package-Requires: ((s "1.6.1") (dash "1.5.0") (noflet "0.0.11"))
+;; Package-Requires: ((s "1.6.1") (dash "1.5.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -30,7 +30,6 @@
 
 ;;; Code:
 
-(require 'noflet)
 (require 'dash)
 (require 's)
 
@@ -104,7 +103,7 @@
 
 (defmacro with-ansi (&rest body)
   "In this block shortcut names (without ansi- prefix) can be used."
-  `(noflet
+  `(cl-flet
        ,(-map
          (lambda (alias)
            (let ((fn (intern (format "ansi-%s" (symbol-name alias)))))


### PR DESCRIPTION
Yep, another one :)


I think `cl-flet` is sufficient for `with-ansi` because we only want to
bind the color names to the functions lexically, not dynamically.

In other words we don't want/need it to work for things like this:
```
(defun foo ()
  (black "foo"))

(with-ansi (foo))
```

In fact it seems like using dynamic flet could even be dangerous here.
For example imagine a user had their own function called `black` that they
intended to call from `foo` in the code above.