### PR TITLE
Revert "enable lexical-binding, require Emacs 24.4"

### DIFF
--- a/ansi.el
+++ b/ansi.el
@@ -1,4 +1,4 @@
-;;; ansi.el --- Turn string into ansi strings  -*- lexical-binding: t; -*-
+;;; ansi.el --- Turn string into ansi strings
 
 ;; Copyright (C) 2010-2013 Johan Andersson
 
@@ -7,7 +7,7 @@
 ;; Version: 0.4.1
 ;; Keywords: terminals color ansi
 ;; URL: http://github.com/rejeep/ansi
-;; Package-Requires: ((emacs "24.4") (s "1.6.1") (dash "1.5.0"))
+;; Package-Requires: ((s "1.6.1") (dash "1.5.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This reverts commit bd9076cc360ac3880879975cf0721f8c24c91aec.

Although the use of lexical-binding is recommended in many
packages, this The changes introduced a major incompatibility to
a historic tool called Cask.

Cask is not very active and it's important that the code that has
been and will continue to work the same way It is.