### PR TITLE
Remove s dependency

### DIFF
--- a/ansi.el
+++ b/ansi.el
@@ -38,8 +38,6 @@
 
 ;;; Code:
 
-(require 'dash)
-(require 's)
 (require 'cl-lib)
 
 (defgroup ansi nil


### PR DESCRIPTION
Related to https://github.com/rejeep/ansi.el/pull/11.
Remove dependency on `s`.