### PR TITLE
Use cl-labels instead of cl-flet.

### DIFF
--- a/ansi.el
+++ b/ansi.el
@@ -123,7 +123,7 @@ This variable affects `with-ansi', `with-ansi-princ'."
   "Shortcut names (without ansi- prefix) can be used in this BODY."
   (if ansi-inhibit-ansi
       `(ansi--concat ,@body)
-    `(cl-flet
+    `(cl-labels
          ,(mapcar
            (lambda (alias)
              (let ((fn (intern (format "ansi-%s" (symbol-name alias)))))


### PR DESCRIPTION
Because cl-lib 0.6 does not define `cl-flet`.
It is needed to use this in Emacs 24.1 and 24.2.