### PR TITLE
Updates and fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,22 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - '24.4'
-          - '24.5'
           - '25.1'
           - '25.2'
           - '25.3'
           - '26.1'
           - '26.2'
           - '26.3'
+          - '27.1'
+          - '27.2'
+          - '28.1'
+          - '28.2'
           - 'snapshot'
         include:
           - emacs_version: 'snapshot'
             allow_failure: true
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}

--- a/README.markdown
+++ b/README.markdown
@@ -86,3 +86,26 @@ this with nesting.
 (with-ansi
  (bold (red (blink "foo bar"))))
 ```
+
+### Inhibit ANSI and CSI sequences
+
+If you are on a dumb terminal, not running on tty or you just want to
+disable colors, you can inhibit all special/control sequences by
+setting `ansi-inhibit-ansi` to `t`.  Text will still be formated and
+output, but without the special/control sequences.
+
+If you are running your Emacs code from shell, for example as a
+wrapper for a binary for your package, you can detect whether you are
+running in a tty with this code:
+
+```bash
+INHIBIT_ANSI="t"
+if [ -t 1 ] ; then
+    INHIBIT_ANSI="nil"
+fi
+
+## here you run your script
+exec emacs --batch --no-init-file --no-site-file --no-splash \
+     --eval "(ansi-inhibit-ansi $INHIBIT_ANSI)" \  ## << disable ansi if not tty
+     --load=elsa --funcall=elsa-run  ## load your package and run your fn
+```

--- a/ansi.el
+++ b/ansi.el
@@ -63,6 +63,17 @@ This variable affects `with-ansi', `with-ansi-princ'."
     (white   . 37))
   "List of text colors.")
 
+(defconst ansi-bright-colors
+  '((bright-black   . 90)
+    (bright-red     . 91)
+    (bright-green   . 92)
+    (bright-yellow  . 93)
+    (bright-blue    . 94)
+    (bright-magenta . 95)
+    (bright-cyan    . 96)
+    (bright-white   . 97))
+  "List of text colors.")
+
 (defconst ansi-on-colors
   '((on-black   . 40)
     (on-red     . 41)
@@ -72,6 +83,17 @@ This variable affects `with-ansi', `with-ansi-princ'."
     (on-magenta . 45)
     (on-cyan    . 46)
     (on-white   . 47))
+  "List of colors to draw text on.")
+
+(defconst ansi-on-bright-colors
+  '((on-bright-black   . 100)
+    (on-bright-red     . 101)
+    (on-bright-green   . 102)
+    (on-bright-yellow  . 103)
+    (on-bright-blue    . 104)
+    (on-bright-magenta . 105)
+    (on-bright-cyan    . 106)
+    (on-bright-white   . 107))
   "List of colors to draw text on.")
 
 (defconst ansi-styles
@@ -105,7 +127,9 @@ This variable affects `with-ansi', `with-ansi-princ'."
   "Return code for EFFECT."
   (or
    (cdr (assoc effect ansi-colors))
+   (cdr (assoc effect ansi-bright-colors))
    (cdr (assoc effect ansi-on-colors))
+   (cdr (assoc effect ansi-on-bright-colors))
    (cdr (assoc effect ansi-styles))))
 
 (defun ansi--char (effect)
@@ -129,7 +153,9 @@ This variable affects `with-ansi', `with-ansi-princ'."
                         ,(list 'backquote (list fn ',string ',@objects)))))
            (append
             (mapcar 'car ansi-colors)
+            (mapcar 'car ansi-bright-colors)
             (mapcar 'car ansi-on-colors)
+            (mapcar 'car ansi-on-bright-colors)
             (mapcar 'car ansi-styles)))
         ,@(mapcar
            (lambda (alias)
@@ -190,6 +216,15 @@ FORMAT-STRING and OBJECTS are processed same as `apply'."
 (ansi--define cyan)
 (ansi--define white)
 
+(ansi--define bright-black)
+(ansi--define bright-red)
+(ansi--define bright-green)
+(ansi--define bright-yellow)
+(ansi--define bright-blue)
+(ansi--define bright-magenta)
+(ansi--define bright-cyan)
+(ansi--define bright-white)
+
 (ansi--define on-black)
 (ansi--define on-red)
 (ansi--define on-green)
@@ -198,6 +233,15 @@ FORMAT-STRING and OBJECTS are processed same as `apply'."
 (ansi--define on-magenta)
 (ansi--define on-cyan)
 (ansi--define on-white)
+
+(ansi--define on-bright-black)
+(ansi--define on-bright-red)
+(ansi--define on-bright-green)
+(ansi--define on-bright-yellow)
+(ansi--define on-bright-blue)
+(ansi--define on-bright-magenta)
+(ansi--define on-bright-cyan)
+(ansi--define on-bright-white)
 
 (ansi--define bold)
 (ansi--define dark)

--- a/ansi.el
+++ b/ansi.el
@@ -117,7 +117,7 @@ This variable affects `with-ansi', `with-ansi-princ'."
   (let ((fn-name (intern (format "ansi-%s" (symbol-name effect)))))
     `(defun ,fn-name (format-string &rest objects)
        ,(format "Add '%s' ansi effect to text." effect)
-       (apply 'ansi-apply (cons ',effect (cons format-string objects))))))
+       (apply 'ansi-apply ',effect format-string objects))))
 
 (defmacro with-ansi (&rest body)
   "Shortcut names (without ansi- prefix) can be used in this BODY."

--- a/ansi.el
+++ b/ansi.el
@@ -109,11 +109,15 @@ This variable affects `with-ansi', `with-ansi-princ'."
   "List of styles.")
 
 (defvar ansi-csis
-  '((up       . "A")
-    (down     . "B")
-    (forward  . "C")
-    (backward . "D"))
-  "...")
+  '((up            . "A")
+    (down          . "B")
+    (forward       . "C")
+    (backward      . "D")
+    (next-line     . "E")
+    (previous-line . "F")
+    (column        . "G")
+    (kill          . "K"))
+  "CSI (Control Sequence Introducer) sequences")
 
 (defconst ansi-reset 0 "Ansi code for reset.")
 
@@ -204,6 +208,27 @@ FORMAT-STRING and OBJECTS are processed same as `apply'."
   "Move N steps (1 step default) backward."
   (ansi-csi-apply 'backward n))
 
+(defun ansi-next-line (&optional n)
+  "Moves cursor to beginning of the line N (default 1) lines down."
+  (ansi-csi-apply 'next-line n))
+
+(defun ansi-previous-line (&optional n)
+  "Moves cursor to beginning of the line N (default 1) lines up."
+  (ansi-csi-apply 'previous-line n))
+
+(defun ansi-column (&optional n)
+  "Moves the cursor to column N (default 1)"
+  (ansi-csi-apply 'column n))
+
+(defun ansi-kill (&optional n)
+  "Erase part of the line.
+
+If N is 0 (or missing), clear from cursor to the end of the line.
+
+If N is 1, clear from cursor to beginning of the line.
+
+If N is 2, clear entire line. Cursor position does not change."
+  (ansi-csi-apply 'kill n))
 
 
 

--- a/ansi.el
+++ b/ansi.el
@@ -124,16 +124,21 @@ This variable affects `with-ansi', `with-ansi-princ'."
   (if ansi-inhibit-ansi
       `(ansi--concat ,@body)
     `(cl-macrolet
-         ,(mapcar
-           (lambda (alias)
-             (let ((fn (intern (format "ansi-%s" (symbol-name alias)))))
-               `(,alias (string &rest objects)
-                        ,(list 'backquote (list fn ',string ',@objects)))))
-           (append
-            (mapcar 'car ansi-colors)
-            (mapcar 'car ansi-on-colors)
-            (mapcar 'car ansi-styles)
-            (mapcar 'car ansi-csis)))
+         (,@(mapcar
+             (lambda (alias)
+               (let ((fn (intern (format "ansi-%s" (symbol-name alias)))))
+                 `(,alias (string &rest objects)
+                          ,(list 'backquote (list fn ',string ',@objects)))))
+             (append
+              (mapcar 'car ansi-colors)
+              (mapcar 'car ansi-on-colors)
+              (mapcar 'car ansi-styles)))
+          ,@(mapcar
+             (lambda (alias)
+               (let ((fn (intern (format "ansi-%s" (symbol-name alias)))))
+                 `(,alias (&optional n)
+                          ,(list 'backquote (list fn ',n)))))
+             (mapcar 'car ansi-csis)))
        ,(cons 'ansi--concat body))))
 
 (defmacro with-ansi-princ (&rest body)

--- a/test/ansi-color-test.el
+++ b/test/ansi-color-test.el
@@ -21,3 +21,27 @@
 
 (ert-deftest test-color-white ()
   (should-color ansi-white 37))
+
+(ert-deftest test-color-bright-black ()
+  (should-color ansi-bright-black 90))
+
+(ert-deftest test-color-bright-red ()
+  (should-color ansi-bright-red 91))
+
+(ert-deftest test-color-bright-green ()
+  (should-color ansi-bright-green 92))
+
+(ert-deftest test-color-bright-yellow ()
+  (should-color ansi-bright-yellow 93))
+
+(ert-deftest test-color-bright-blue ()
+  (should-color ansi-bright-blue 94))
+
+(ert-deftest test-color-bright-magenta ()
+  (should-color ansi-bright-magenta 95))
+
+(ert-deftest test-color-bright-cyan ()
+  (should-color ansi-bright-cyan 96))
+
+(ert-deftest test-color-bright-white ()
+  (should-color ansi-bright-white 97))

--- a/test/ansi-csi-test.el
+++ b/test/ansi-csi-test.el
@@ -19,6 +19,7 @@
   (should (equal (ansi-backward 2) "\u001b[2D")))
 
 (ert-deftest ansi-csi-test/with-ansi ()
+  (should (equal (with-ansi (up)) (ansi-up 1)))
   (should (equal (with-ansi (up 3)) (ansi-up 3)))
   (should (equal (with-ansi (down 3)) (ansi-down 3)))
   (should (equal (with-ansi (forward 3)) (ansi-forward 3)))

--- a/test/ansi-csi-test.el
+++ b/test/ansi-csi-test.el
@@ -18,8 +18,29 @@
   (should (equal (ansi-backward 1) "\u001b[1D"))
   (should (equal (ansi-backward 2) "\u001b[2D")))
 
+(ert-deftest ansi-csi-test/next-line ()
+  (should (equal (ansi-next-line) "\u001b[1E"))
+  (should (equal (ansi-next-line 1) "\u001b[1E"))
+  (should (equal (ansi-next-line 2) "\u001b[2E")))
+
+(ert-deftest ansi-csi-test/previous-line ()
+  (should (equal (ansi-previous-line) "\u001b[1F"))
+  (should (equal (ansi-previous-line 1) "\u001b[1F"))
+  (should (equal (ansi-previous-line 2) "\u001b[2F")))
+
+(ert-deftest ansi-csi-test/column ()
+  (should (equal (ansi-column) "\u001b[1G"))
+  (should (equal (ansi-column 1) "\u001b[1G"))
+  (should (equal (ansi-column 2) "\u001b[2G")))
+
+(ert-deftest ansi-csi-test/kill ()
+  (should (equal (ansi-kill) "\u001b[1K"))
+  (should (equal (ansi-kill 1) "\u001b[1K"))
+  (should (equal (ansi-kill 2) "\u001b[2K")))
+
 (ert-deftest ansi-csi-test/with-ansi ()
   (should (equal (with-ansi (up)) (ansi-up 1)))
+  (should (equal (with-ansi (kill)) (ansi-kill 1)))
   (should (equal (with-ansi (up 3)) (ansi-up 3)))
   (should (equal (with-ansi (down 3)) (ansi-down 3)))
   (should (equal (with-ansi (forward 3)) (ansi-forward 3)))

--- a/test/ansi-dsl-on-color-test.el
+++ b/test/ansi-dsl-on-color-test.el
@@ -30,6 +30,38 @@
   (with-ansi
    (should-color on-white 47)))
 
+(ert-deftest test-dsl-color-bright-black ()
+  (with-ansi
+   (should-color on-bright-black 100)))
+
+(ert-deftest test-dsl-color-bright-red ()
+  (with-ansi
+   (should-color on-bright-red 101)))
+
+(ert-deftest test-dsl-color-bright-green ()
+  (with-ansi
+   (should-color on-bright-green 102)))
+
+(ert-deftest test-dsl-color-bright-yellow ()
+  (with-ansi
+   (should-color on-bright-yellow 103)))
+
+(ert-deftest test-dsl-color-bright-blue ()
+  (with-ansi
+   (should-color on-bright-blue 104)))
+
+(ert-deftest test-dsl-color-bright-magenta ()
+  (with-ansi
+   (should-color on-bright-magenta 105)))
+
+(ert-deftest test-dsl-color-bright-cyan ()
+  (with-ansi
+   (should-color on-bright-cyan 106)))
+
+(ert-deftest test-dsl-color-bright-white ()
+  (with-ansi
+   (should-color on-bright-white 107)))
+
 (ert-deftest test-dsl-combined-colors ()
   (let ((actual
          (with-ansi

--- a/test/ansi-inhibit-test.el
+++ b/test/ansi-inhibit-test.el
@@ -1,0 +1,19 @@
+(ert-deftest test-inhibit-ansi-apply ()
+  (let ((ansi-inhibit-ansi t))
+    (should (equal
+             (with-ansi (red "hello %s" "world"))
+             "hello world"))))
+
+(ert-deftest test-inhibit-ansi-apply-nested ()
+  (let ((ansi-inhibit-ansi t))
+    (should (equal
+             (with-ansi "some text "
+                        (red "hello %s " "world")
+                        (bold (black "black bold %d" 42)))
+             "some text hello world black bold 42"))))
+
+(ert-deftest test-inhibit-ansi-csi-apply ()
+  (let ((ansi-inhibit-ansi t))
+    (should (equal
+             (with-ansi "hello" (backward))
+             "hello"))))

--- a/test/ansi-on-color-test.el
+++ b/test/ansi-on-color-test.el
@@ -21,3 +21,27 @@
 
 (ert-deftest test-color-on-white ()
   (should-color ansi-on-white 47))
+
+(ert-deftest test-color-on-bright-black ()
+  (should-color ansi-on-bright-black 100))
+
+(ert-deftest test-color-on-bright-red ()
+  (should-color ansi-on-bright-red 101))
+
+(ert-deftest test-color-on-bright-green ()
+  (should-color ansi-on-bright-green 102))
+
+(ert-deftest test-color-on-bright-yellow ()
+  (should-color ansi-on-bright-yellow 103))
+
+(ert-deftest test-color-on-bright-blue ()
+  (should-color ansi-on-bright-blue 104))
+
+(ert-deftest test-color-on-bright-magenta ()
+  (should-color ansi-on-bright-magenta 105))
+
+(ert-deftest test-color-on-bright-cyan ()
+  (should-color ansi-on-bright-cyan 106))
+
+(ert-deftest test-color-on-bright-white ()
+  (should-color ansi-on-bright-white 107))


### PR DESCRIPTION
I realize this is not best practice but I just made the changes very fast and didn't split them in separate branches because one depended on another.

Fixes #2

Fixes #6 

You can go commit-by-commit as they are self-contained.

I will merge this later in the week if there's no objections.

Biggest change is in the last commit, where the `with-ansi` macro just directly expands the "DSL forms" instead of generating the huge cl-macrolet form.

```emacs-lisp
     (with-ansi
      (previous-line)
      (kill)
      (green "[%s]" (elsa-global-state-get-counter global-state))
      (format " Processing file %s ... " file)
      (green "done")
      " after "
      (let ((duration (float-time
                       (time-subtract
                        (current-time) current-time))))
        (cond
         ((> duration 5)
          (bright-red "%.3fs" duration))
         ((> duration 2)
          (bright-yellow "%.3fs" duration))
         (t (green "%.3fs" duration)))))
```

becomes

```emacs-lisp
     (ansi--concat
      (ansi-previous-line)
      (ansi-kill)
      (ansi-green "[%s]"
                  (elsa-global-state-get-counter global-state))
      (format " Processing file %s ... " file)
      (ansi-green "done")
      " after "
      (let
          ((duration
            (float-time
             (time-subtract
              (current-time)
              current-time))))
        (cond
         ((> duration 5)
          (ansi-bright-red "%.3fs" duration))
         ((> duration 2)
          (ansi-bright-yellow "%.3fs" duration))
         (t
          (ansi-green "%.3fs" duration)))))
```